### PR TITLE
update syn dependency on match-lookup

### DIFF
--- a/match_lookup/Cargo.toml
+++ b/match_lookup/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
Hi, we are depending on `match-lookup` transitively via `multiaddr` on Lighthouse and `rust-libp2p` and it's only dependency that still uses `syn v1.0`.
This PR addresses that.
Thanks 