### PR TITLE
chore(deps): bump syn from 2.0 to 3.0 in match_lookup

### DIFF
--- a/match_lookup/Cargo.toml
+++ b/match_lookup/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
Update the syn dependency to the 3.0 major release for the match-lookup proc-macro crate.